### PR TITLE
Pod corrections + 2 more test files for more explicit direct sub tests

### DIFF
--- a/lib/GraphViz2.pm
+++ b/lib/GraphViz2.pm
@@ -72,9 +72,9 @@ has global =>
 
 has graph =>
 (
-	default  => sub{return ''},
+	default  => sub{return {} },
 	is       => 'rw',
-	#isa      => HashRef,
+	isa      => HashRef,
 	required => 0,
 );
 
@@ -1742,7 +1742,7 @@ $level defaults to 'debug', and $message defaults to ''.
 
 If called with $level eq 'error', it dies with $message.
 
-=head2 logger($logger_object])
+=head2 logger($logger_object)
 
 Gets or sets the log object.
 

--- a/lib/GraphViz2/Filer.pm
+++ b/lib/GraphViz2/Filer.pm
@@ -159,7 +159,7 @@ It returns a new object of type C<GraphViz2::Filer>.
 
 =head1 Methods
 
-=head1 get_annotations()
+=head2 get_annotations()
 
 Returns a hash (sic) keyed by *.pl name, with the values being the text off line 3 of each script.
 

--- a/t/test_more_methods.t
+++ b/t/test_more_methods.t
@@ -11,7 +11,9 @@ use GraphViz2;
 
 # ------------------------------------------------
 
-my $GraphViz2 = GraphViz2->new();
+my $GraphViz2 = GraphViz2->new(
+    im_meta => { URL => "http://savage.net.au/maps/demo.4.html" }
+);
 my $count     = 0;
 
 my %methods = (
@@ -29,21 +31,38 @@ my %methods = (
     },
     pop_subgraph            => { id => 6,  args => {} },
     report_valid_attributes => { id => 7,  args => {} },
-    run                     => { id => 8,  args => {} },
-    run_map                 => { id => 9,  args => {} },
-    run_mapless             => { id => 10, args => {} },
+    run_map                 => { 
+        id => 8,  
+        subname => 'run', 
+        args => {
+            format => 'png',
+            output_file => 't/test_more_run_map.png', 
+            im_output_file => 't/test_more_run_map.map', 
+            im_format => 'cmapx',
+        }, 
+    },
+    run_mapless             => { 
+        id => 9,  
+        subname => 'run', 
+        args => {
+            format => 'png',
+            output_file => 't/test_more_run_mapless.png', 
+        },
+    }, 
 );
 foreach my $sub ( sort { $methods{$a}{id} <=> $methods{$b}{id} } keys %methods )
 {
 
+    my $subname = defined $methods{$sub}{'subname'} ? $methods{$sub}{'subname'} : $sub;
+
     # Check we can call this function/method/sub
     $count++;
-    can_ok( $GraphViz2, $sub );
+    can_ok( $GraphViz2, $subname );
 
     $count++;
     ok(
-        $GraphViz2->$sub( %{ $methods{$sub}{'args'} } ),
-        "Run $sub with -> "
+        $GraphViz2->$subname( %{ $methods{$sub}{'args'} } ),
+        "Run $subname with -> "
           . join(
             ", ", map { "$_:$methods{$sub}{'args'}{$_}" } keys %{ $methods{$sub}{'args'} }
           )

--- a/t/test_more_methods.t
+++ b/t/test_more_methods.t
@@ -1,0 +1,53 @@
+use strict;
+use utf8;
+use warnings;
+use warnings qw(FATAL utf8);       # Fatalize encoding glitches.
+use open qw(:std :utf8);           # Undeclared streams in UTF-8.
+use charnames qw(:full :short);    # Unneeded in v5.16.
+
+use Data::Dumper;
+use Test::More;
+use GraphViz2;
+
+# ------------------------------------------------
+
+my $GraphViz2 = GraphViz2->new();
+my $count     = 0;
+
+my %methods = (
+    add_node => { id => 1, args => { name => 'TestNode1', label => 'n1' } },
+    add_edge => { id => 2, args => { from => 'TestNode1', to    => '' } },
+    default_subgraph  => { id => 3, args => {} },
+    escape_some_chars => { id => 4, args => { $GraphViz2, "abc123[]()" } },
+    push_subgraph => {
+        id   => 5,
+        args => {
+            name  => 'subgraph_test',
+            edge  => {},
+            graph => { bgcolor => 'grey', label => 'subgraph_test' }
+        }
+    },
+    pop_subgraph            => { id => 6,  args => {} },
+    report_valid_attributes => { id => 7,  args => {} },
+    run                     => { id => 8,  args => {} },
+    run_map                 => { id => 9,  args => {} },
+    run_mapless             => { id => 10, args => {} },
+);
+foreach my $sub ( sort { $methods{$a}{id} <=> $methods{$b}{id} } keys %methods )
+{
+
+    # Check we can call this function/method/sub
+    $count++;
+    can_ok( $GraphViz2, $sub );
+
+    $count++;
+    ok(
+        $GraphViz2->$sub( %{ $methods{$sub}{'args'} } ),
+        "Run $sub with -> "
+          . join(
+            ", ", map { "$_:$methods{$sub}{'args'}{$_}" } keys %{ $methods{$sub}{'args'} }
+          )
+    );
+}
+done_testing($count);
+

--- a/t/test_new.t
+++ b/t/test_new.t
@@ -1,0 +1,18 @@
+use strict;
+use utf8;
+use warnings;
+use warnings  qw(FATAL utf8);    # Fatalize encoding glitches.
+use open      qw(:std :utf8);    # Undeclared streams in UTF-8.
+use charnames qw(:full :short);  # Unneeded in v5.16.
+
+use Test::More;
+
+# ------------------------------------------------
+
+BEGIN{ use_ok('GraphViz2'); }
+
+my($count)  = 1; # Counting the use_ok above.
+$count++;
+my $GraphViz2 = new_ok('GraphViz2');
+done_testing($count);
+


### PR DESCRIPTION
Hi Ron,
I've recently signed up to help contribute to CPAN via the PRC i.e. 'P'ull 'R'equest 'C'hallenge.
I was assigned the GraphViz2 distribution (well, after the first one scaring the bejeezers out of me 'Math::Prime::Util' I asked for a re-assignment) and directed to some helpful ideas on how to make a useful pull request.

I've done the following to generate this current pull request
1.  find all **.pl** and **.pm** files and run **podchecker** against them. e.g.
`cd /path/to/GraphViz2`
` find ./ -name "*.p[lm]" -exec podchecker {} \;`
I found 2 errors, a typo and a head hierarchy clash.
 2. This one I am more dubious about as I'm not massively familiar with **Devel::Cover** in fact this was my first outing with this package. So I ran the following below and looked at the generated **./cover_db/coverage.html** e.g. 
`cd /path/to/GraphViz2`
`cover -test` 
I'm in doubt as to whether GraphViz2 requires direct sub checking as the **scripts/** tests usable examples rather than single function calls. However I've created 2 more specific test files that do just this, so the final coverage.html shows a much greater percentage covering of subs. NB without fully understanding what the tests are doing I've added minimal arguments to these subs so the sub called executes without error. The new test files are below and will run with `make test` or `cover -test`
`t/test_new.t`
`t/test_more_methods.t`

Please let me know what you think